### PR TITLE
fix: Windows support — audio detection, shortcuts, and Win32 Input Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@
 
 | Hotkey / Command | What it does |
 |--------|-------------|
-| **Ctrl+R** | Start / stop voice recording → transcription is typed into your prompt |
-| **Ctrl+P** | Screenshot picker → file path is injected as `@/path/screenshot.png` |
+| **Ctrl+G** | Start / stop voice recording → transcription is typed into your prompt |
+| **Ctrl+O** | Screenshot picker → file path is injected as `@/path/screenshot.png` |
 | **Ctrl+K** | Open command palette — access all features from a searchable menu |
 | **Option+Shift+1–4** *(macOS Terminal.app)* | Switch to workhorse model slot 1–4 — requires "Use Option as Meta Key" |
 | **Ctrl+Shift+1–4** *(kitty/WezTerm/Windows Terminal)* | Switch to workhorse model slot 1–4 on CSI u–capable terminals |
@@ -133,12 +133,12 @@ That's it. You're now inside Copilot CLI with voice and screenshot support activ
 
 ## Using Voice Input
 
-1. **Press `Ctrl+R`** to start recording.  
+1. **Press `Ctrl+G`** to start recording.  
    A system notification appears and your terminal title changes to `🎙 Recording…`
 
 2. **Speak your prompt** naturally — e.g. _"refactor this function to use async await"_
 
-3. **Press `Ctrl+R` again** to stop.  
+3. **Press `Ctrl+G` again** to stop.  
    Transcription runs locally (`⏳ Transcribing…`) — no audio ever leaves your machine.
 
 4. **Your words appear as text** in the Copilot prompt. Review and edit if needed, then press **Enter** to send.
@@ -149,9 +149,9 @@ That's it. You're now inside Copilot CLI with voice and screenshot support activ
 
 ## Using Screenshots
 
-**macOS:** Press `Ctrl+P` — the interactive screenshot overlay opens (same UI as `⌘⇧4`). Click and drag to select any area. The file path is injected into your prompt as `@/tmp/copilot-screenshots/screenshot-<timestamp>.png`.
+**macOS:** Press `Ctrl+O` — the interactive screenshot overlay opens (same UI as `⌘⇧4`). Click and drag to select any area. The file path is injected into your prompt as `@/tmp/copilot-screenshots/screenshot-<timestamp>.png`.
 
-**Windows:** Press `Ctrl+P` — the Snip & Sketch overlay opens (same as `Win+Shift+S`). Draw a selection; the file path is injected automatically when you complete the snip.
+**Windows:** Press `Ctrl+O` — the Snip & Sketch overlay opens (same as `Win+Shift+S`). Draw a selection; the file path is injected automatically when you complete the snip.
 
 Add context if you want (e.g. _"what's wrong with this?"_), then press **Enter**.
 
@@ -395,8 +395,8 @@ Then update `modelPath` in `~/.copilot/copilot-plus.json`.
 │  copilot+ (PTY wrapper)                                            │
 │                                                                    │
 │  Your keystrokes ──► intercept hotkeys                             │
-│                      ├── Ctrl+R         → push-to-talk recording   │
-│                      ├── Ctrl+P         → screenshot picker         │
+│                      ├── Ctrl+G         → push-to-talk recording   │
+│                      ├── Ctrl+O         → screenshot picker         │
 │                      ├── Ctrl+K         → command palette overlay   │
 │                      ├── Opt+⇧1–4       → switch workhorse model    │
 │                      ├── Ctrl+⇧1–4      → switch workhorse model    │

--- a/bin/copilot+
+++ b/bin/copilot+
@@ -10,6 +10,13 @@ const { runOnboarding } = require('../src/onboarding');
 const AgentMonitor = require('../src/monitor');
 
 const IS_WIN = os.platform() === 'win32';
+
+// Disable Win32 Input Mode if active — Windows Terminal sends all key events
+// as escape sequences in this mode, breaking readline and raw input parsing.
+if (IS_WIN && process.stdout.isTTY) {
+  process.stdout.write('\x1b[?9001l');
+}
+
 // `which` on Unix, `where` on Windows
 const WHICH = IS_WIN ? 'where' : 'which';
 
@@ -181,8 +188,8 @@ function runSetup() {
 }
 
 function printHotkeysAndExit(allGood) {
-  console.log('  Ctrl+R  →  Start / stop voice recording');
-  console.log('  Ctrl+P  →  Take a screenshot (injected as @path)');
+  console.log('  Ctrl+G  →  Start / stop voice recording');
+  console.log('  Ctrl+O  →  Take a screenshot (injected as @path)');
   console.log('  Ctrl+K  →  Open command palette');
   console.log('  Option+1–9 →  Execute prompt macro (enable "Use Option as Meta Key" in Terminal settings)');
   console.log('  Ctrl+1–9   →  Execute prompt macro (CSI u terminals: kitty, WezTerm)');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "copilot-plus",
-  "version": "1.0.14",
+  "version": "1.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-plus",
-      "version": "1.0.14",
+      "version": "1.0.25",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@picovoice/porcupine-node": "^3.0.0",
-        "@picovoice/pvrecorder-node": "^1.2.0",
         "node-pty": "^1.0.0"
       },
       "bin": {
@@ -19,30 +17,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@picovoice/porcupine-node": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@picovoice/porcupine-node/-/porcupine-node-3.0.6.tgz",
-      "integrity": "sha512-vYlY0Hf9ovRB+Z9yyLReiVYZkLsm/kVPgDWTu2dgtqAooednohljfxSRzJUojapp8BFd7aW8P3H/4sm1zy49lw==",
-      "cpu": [
-        "!ia32",
-        "!mips",
-        "!ppc",
-        "!ppc64"
-      ],
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@picovoice/pvrecorder-node": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@picovoice/pvrecorder-node/-/pvrecorder-node-1.2.8.tgz",
-      "integrity": "sha512-dbLJlplQQNRkM2ja/hP4sRADGDILuJ54dEf8cU5eULeNrddxXvOtE8IiJ5F2VhhbXmIv3Qmn79DqhttCOxjH8Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 const CONFIG_PATH = path.join(os.homedir(), '.copilot', 'copilot-plus.json');
 
@@ -58,12 +58,15 @@ function detectMicrophone() {
 
 function detectMicrophoneWindows() {
   try {
-    const output = execFileSync('ffmpeg', [
+    // Use spawnSync so we always capture stderr regardless of exit code.
+    // Some ffmpeg versions on Windows exit 0 even for device listing, so
+    // execFileSync's catch-based stderr access doesn't work reliably.
+    const result = spawnSync('ffmpeg', [
       '-f', 'dshow', '-list_devices', 'true', '-i', 'dummy',
     ], { encoding: 'utf8', stdio: ['ignore', 'ignore', 'pipe'] });
-    return parseBestMicWindows(output);
-  } catch (err) {
-    return parseBestMicWindows(err.stderr || '');
+    return parseBestMicWindows(result.stderr || '');
+  } catch {
+    return null;
   }
 }
 
@@ -132,12 +135,12 @@ function parseMicDevicesWindows(output) {
 function listMicDevices() {
   if (os.platform() === 'win32') {
     try {
-      const output = execFileSync('ffmpeg', [
+      const result = spawnSync('ffmpeg', [
         '-f', 'dshow', '-list_devices', 'true', '-i', 'dummy',
       ], { encoding: 'utf8', stdio: ['ignore', 'ignore', 'pipe'] });
-      return parseMicDevicesWindows(output);
-    } catch (err) {
-      return parseMicDevicesWindows(err.stderr || '');
+      return parseMicDevicesWindows(result.stderr || '');
+    } catch {
+      return [];
     }
   } else {
     try {

--- a/src/onboarding.js
+++ b/src/onboarding.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const readline = require('readline');
+const os = require('os');
 const config = require('./config');
 
 /**
@@ -9,6 +10,12 @@ const config = require('./config');
  * Returns the updated config object.
  */
 async function runOnboarding(cfg) {
+  // Disable Win32 Input Mode — Windows Terminal may send key events as escape
+  // sequences that readline cannot parse, producing garbled output.
+  if (os.platform() === 'win32' && process.stdout.isTTY) {
+    process.stdout.write('\x1b[?9001l');
+  }
+
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
 
   const ask = (q) => new Promise(resolve => rl.question(q, resolve));
@@ -28,7 +35,7 @@ async function runOnboarding(cfg) {
     cfg.wakeWord.phrase = phrase || defaultPhrase;
     console.log(`✅  Voice activation enabled. Say "${cfg.wakeWord.phrase}" to start recording.\n`);
   } else {
-    console.log('    Voice activation disabled. Use Ctrl+R to record manually. Enable it later via Ctrl+K.\n');
+    console.log('    Voice activation disabled. Use Ctrl+G to record manually. Enable it later via Ctrl+K.\n');
   }
 
   // --- Prompt macros ---

--- a/src/wrapper.js
+++ b/src/wrapper.js
@@ -21,8 +21,8 @@ const ACTIVE_PID_FILE = path.join(os.homedir(), '.copilot', 'copilot-plus-active
 
 const IS_WIN = os.platform() === 'win32';
 
-const CTRL_R = '\x12';
-const CTRL_P = '\x10';
+const CTRL_G = '\x07';
+const CTRL_O = '\x0f';
 const CTRL_C = '\x03';
 const CTRL_K = '\x0b';
 
@@ -33,6 +33,45 @@ const MODEL_SLOT_CSI_U_RE = /^\x1b\[(\d+);6u$/;
 // Shift+1=!  Shift+2=@  Shift+3=#  Shift+4=$  → Meta prefix makes \x1b! etc.
 const MODEL_SLOT_META_RE = /^\x1b([!@#$])$/;
 const META_SHIFTED_MAP = { '!': 1, '@': 2, '#': 3, '$': 4 };
+
+/**
+ * Translate Win32 Input Mode sequences emitted by Windows Terminal.
+ * Format: ESC [ Vk ; Sc ; Uc ; Kd ; Cs ; Rc _
+ * Returns the translated key string for key-down events,
+ * empty string for events to discard (key-up), or null if not Win32 Input Mode.
+ */
+function translateWin32Input(str) {
+  const seqRe = /\x1b\[([\d;]*)_/g;
+  let result = '';
+  let matched = false;
+  let m;
+  while ((m = seqRe.exec(str)) !== null) {
+    matched = true;
+    const parts = m[1].split(';').map(s => parseInt(s, 10) || 0);
+    if (parts.length < 4) continue;
+    const vk = parts[0];
+    const uc = parts[2];
+    const kd = parts[3];
+    if (!kd) continue; // Ignore key-up events
+    if (uc > 0) {
+      result += String.fromCharCode(uc);
+    } else {
+      // Non-character keys: translate VK codes to ANSI escape sequences
+      switch (vk) {
+        case 38: result += '\x1b[A'; break;  // Up
+        case 40: result += '\x1b[B'; break;  // Down
+        case 37: result += '\x1b[D'; break;  // Left
+        case 39: result += '\x1b[C'; break;  // Right
+        case 36: result += '\x1b[H'; break;  // Home
+        case 35: result += '\x1b[F'; break;  // End
+        case 46: result += '\x1b[3~'; break; // Delete
+        case 27: result += '\x1b'; break;    // Escape
+      }
+    }
+  }
+  if (!matched) return null;
+  return result;
+}
 
 // Token/model patterns to scan from stripped PTY output (best-effort)
 const TOKEN_PATTERNS = [
@@ -116,6 +155,10 @@ class CopilotWrapper {
     process.stdout.on('resize', () => {
       try { shell.resize(process.stdout.columns, process.stdout.rows); } catch {}
     });
+
+    // Disable Win32 Input Mode if active — Windows Terminal may send all key
+    // events as CSI sequences which breaks raw control-code comparisons.
+    if (IS_WIN) process.stdout.write('\x1b[?9001l');
 
     process.stdin.setRawMode(true);
     process.stdin.resume();
@@ -230,10 +273,17 @@ class CopilotWrapper {
   }
 
   _handleInput(data) {
-    const key = data.toString();
+    let key = data.toString();
+
+    // Translate Win32 Input Mode sequences (Windows Terminal enhanced input)
+    const translated = translateWin32Input(key);
+    if (translated !== null) {
+      if (translated === '') return; // Key-up or unrecognized — discard
+      key = translated;
+    }
 
     if (this.palette.isOpen) {
-      this.palette.handleInput(data);
+      this.palette.handleInput(key);
       return;
     }
 
@@ -274,7 +324,7 @@ class CopilotWrapper {
       return;
     }
 
-    if (key === CTRL_R) {
+    if (key === CTRL_G) {
       if (this.voice.isRecording) {
         this._stopVoice();
       } else {
@@ -283,7 +333,7 @@ class CopilotWrapper {
       return;
     }
 
-    if (key === CTRL_P) {
+    if (key === CTRL_O) {
       this._doScreenshot();
       return;
     }
@@ -316,8 +366,8 @@ class CopilotWrapper {
       : '🗣️   Voice Activation: off';
 
     const actions = [
-      { id: 'voice', label: '🎙  Voice Recording', hint: 'Ctrl+R' },
-      { id: 'screenshot', label: '📸  Screenshot', hint: 'Ctrl+P' },
+      { id: 'voice', label: '🎙  Voice Recording', hint: 'Ctrl+G' },
+      { id: 'screenshot', label: '📸  Screenshot', hint: 'Ctrl+O' },
       { id: 'voice-activation-toggle', label: vaLabel, hint: 'toggle' },
     ];
 
@@ -451,8 +501,8 @@ class CopilotWrapper {
     try {
       this.voice.start();
       agentState.writeState(this._pid, { status: 'recording' });
-      this._setTitle('🎙 Recording… (Ctrl+R to stop, Ctrl+C to cancel)');
-      this._notify('🎙 Recording started', 'Press Ctrl+R to stop');
+      this._setTitle('🎙 Recording… (Ctrl+G to stop, Ctrl+C to cancel)');
+      this._notify('🎙 Recording started', 'Press Ctrl+G to stop');
     } catch (err) {
       this._notify('❌ Could not start recording', err.message);
       if (this.cfg.wakeWord && this.cfg.wakeWord.enabled) {


### PR DESCRIPTION
- Use spawnSync instead of execFileSync for Windows ffmpeg device listing. On Windows, ffmpeg exits with code 0 for device enumeration, so execFileSync never throws and the stderr-based catch path is skipped.

- Change voice recording shortcut from Ctrl+R to Ctrl+G and screenshot from Ctrl+P to Ctrl+O to avoid conflicts with readline shortcuts in copilot-cli (reverse-i-search and previous-history).

- Handle Win32 Input Mode on Windows Terminal: disable it at startup (ESC[?9001l) and add translateWin32Input() fallback parser that decodes Win32 Input Mode escape sequences back to normal characters.

Most likely it should not be merged as is, but these changes solved my issues on windows - see https://www.reddit.com/r/GithubCopilot/comments/1rn2m6q/comment/o9uyzmq/