### PR TITLE
fix: clamp percentage in _miniBar to prevent negative repeat count

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -93,7 +93,8 @@ function fmtNum(n) {
 
 /** Render a compact text progress bar, e.g. "████░░░░░░░░" for pct=33 */
 function _miniBar(pct, width) {
-  const filled = Math.round((pct / 100) * width);
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.round((clamped / 100) * width);
   const empty  = width - filled;
   const color  = pct >= 80 ? YELLOW : DIM;
   return `${color}${'█'.repeat(filled)}${'░'.repeat(empty)}${R}`;


### PR DESCRIPTION
When pct exceeds 100 (e.g. premium quota usage > entitlement), the filled count exceeds width, making empty negative and crashing String.repeat() with RangeError: Invalid count value. Clamp pct to 0-100 before computing bar segments.